### PR TITLE
Expose the new L3TETAUX product over the older L3T products

### DIFF
--- a/ECOv003_granules/ECOv003_granules.py
+++ b/ECOv003_granules/ECOv003_granules.py
@@ -2,9 +2,7 @@ from .colors import *
 from .L2TLSTE import L2TLSTE
 from .L2TSTARS import L2TSTARS
 from .L3TJET import L3TJET
-from .L3TMET import L3TMET
-from .L3TSEB import L3TSEB
-from .L3TSM import L3TSM
+from .L3TETAUX import L3TETAUX
 from .L4TESI import L4TESI
 from .L4TWUE import L4TWUE
 from .granule import ECOSTRESSGranule


### PR DESCRIPTION
This does not remove the older L3T products, it just doesn't expose them from the root import anymore.