### PR TITLE
Fix missed change to L2TSTARS timestamp section

### DIFF
--- a/ECOv003_granules/L2TSTARS.py
+++ b/ECOv003_granules/L2TSTARS.py
@@ -177,6 +177,6 @@ class L2TSTARS(ECOSTRESSTiledGranule, L2STARSGranule):
         if isinstance(time_UTC, str):
             time_UTC = parser.parse(time_UTC)
 
-        granule_name = f"ECOv{collection}_{product_name}_{tile}_{time_UTC:%Y%m%dT%H%M%S}_{process_count:02d}"
+        granule_name = f"ECOv{collection}_{product_name}_{tile}_{time_UTC:%Y%m%d}_{process_count:02d}"
 
         return granule_name


### PR DESCRIPTION
In Collection 2, there was a refactor to change L2T_STARS from using `{time_UTC:%Y%m%dT%H%M%S}` to using `{time_UTC:%Y%m%d}`. This missed this particular call site, which just happens to be the call site I standardized on 🙃.

Reference link to the old repo for those with access: https://github.jpl.nasa.gov/ecostress/ECOSTRESS-Collection-2/commit/ce954a17b212a59518eb3c3eac268d0a88f9b57b